### PR TITLE
DEVOPS-499 :: Keep dependencies versions aligned between repositories

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,23 @@
 --requirement requirements.txt
 
-black==22.8.0                                   # The uncompromising code formatter
-bandit==1.7.4                                   # A Python source code security analyzer
-pip-upgrader==1.4.15                            # Helps to upgrade requirements.txt
-pylint==2.14.5                                  # Linter (cannot update further without breaking integration with pylint-django)
+### Requirements (development) (alphabetical order)
+bandit==1.7.4                                   # Security oriented static analyser for Python code
+black==22.10.0                                  # The uncompromising code formatter
+bump2version==1.0.1                             # Version-bump your software with a single command!
+coverage==6.5.0                                 # Code coverage measurement for Python
+pip-upgrader==1.4.15                            # An interactive pip requirements upgrader (it also updates the version in your requirements.txt file)
+pygments-pytest==2.2.0                          # A pygments lexer for pytest output
+pylint==2.15.2                                  # Python code static checker (cannot update further without breaking integration with pylint-django)
+pympler==1.0.1                                  # A development tool to measure, monitor and analyze the memory behavior of Python objects
+pyre-check==0.9.16                              # A performant type checker for Python
+pyre-extensions==0.0.29                         # Type system extensions for use with the pyre type checker
+pytest==7.1.3                                   # Pytest: simple powerful testing with Python
+pytest-asyncio==0.19.0                          # Pytest plugin for asyncio support
+pytest-cov==3.0.0                               # Pytest plugin for measuring coverage
+pytest-github-actions-annotate-failures==0.1.7  # Pytest plugin to annotate failed tests with a workflow command for GitHub Actions
+pytest-instafail==0.4.2                         # Pytest plugin to show failures instantly
+pytest-pylint==0.19.0                           # Pytest plugin to check source code with pylint
+pytest-sugar==0.9.5                             # Pytest plugin that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)
+pytest-timeout==2.1.0                           # Pytest plugin to abort hanging tests
+pytest-xdist==2.5.0                             # Pytest plugin for distributed testing and loop-on-failing modes
+vulture==2.6                                    # Find dead code

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,7 @@
+### Requirements (documentation) (alphabetical order)
+graphviz==0.20.1                                # Simple Python interface for Graphviz
+rstcheck==6.1.0                                 # Checks syntax of reStructuredText and code blocks nested within it
+Sphinx==5.2.2                                   # Python documentation generator
+sphinx-automodapi==0.14.1                       # Sphinx extension for auto-generating API documentation for entire modules
+sphinxcontrib-plantuml==0.24                    # Sphinx "plantuml" extension
+sphinx_rtd_theme==1.0.0                         # Read the Docs theme for Sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-# Valispace packages
-valispace==0.1.16   # Valispace API
-
-# Basic scientifical packages
-oct2py==5.3.0       # Python interface to Octave
-pint==0.18          # Python library used for scientific
-scipy==1.7.3        # Python library to define, operate and manipulate physical quantities
+### Requirements (alphabetical order)
+valispace==0.1.16                               # Valispace API
+### Basic scientifical packages (alphabetical order)
+scipy==1.7.3                                    # Scientific Library for Python
+pint==0.18                                      # Physical quantities module
+oct2py==5.3.0                                   # Python to GNU Octave bridge


### PR DESCRIPTION
1. Dependencies reordered by alphabetical order;
2. Dependencies updated to the latest release available (except `Django`);
3. List of dependencies kept equal between projects, as much as possible;
4. Common dependency '`scipy`' moved to `valifn` dependencies list;


For more details see: [DEVOPS-499](https://valispace.atlassian.net/browse/DEVOPS-499)