### PR TITLE
DEVOPS-552 :: Review valifn-octave coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,20 +1,37 @@
 [run]
 omit =
-    */commands/*
-    */factories/*
-    */migrations/*
-    */settings/*
-    */tests/*
+    **/commands/**
+    **/factories/**
+    **/migrations/**
+    **/settings/**
+    **/tests/*
+    .venv/*
+    .env/*
     *__init__.py
     *admin.py
     *quantities.py
     *renderers.py
     *storage.py
-    *tests.py
+    *test*.py
     *wsgi.py
 
 [report]
 sort = -cover
+omit =
+    **/commands/**
+    **/factories/**
+    **/migrations/**
+    **/settings/**
+    **/tests/*
+    .venv/*
+    .env/*
+    *__init__.py
+    *admin.py
+    *quantities.py
+    *renderers.py
+    *storage.py
+    *test*.py
+    *wsgi.py
 
 [html]
 directory = coverage


### PR DESCRIPTION
* `coverage` configurations reviewed and tested, guaranteeing that only relevante source code is reported

For more details see: [DEVOPS-552](https://valispace.atlassian.net/browse/DEVOPS-552)