### PR TITLE
DEVOPS-663 :: Disable "no-else-return" warning in valifn project

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -98,6 +98,7 @@ disable=raw-checker-failed,
         attribute-defined-outside-init,
         signature-differs,
         #imported-auth-user,
+        no-else-return  # an else-return is more readable
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Warning "`no-else-return`" added to `tool.pylint."messages control".disable` list of disabled rules.

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-octave/pull/30/commits/3e81a9f795a2c2f2d2f9ebd89fa49389643ee53c"><code>3e81a9f</code></a> Warning "R1705: (no-else-return)" disabled
</li>
</ul>
</details>

<hr>

_More details about this issue at [DEVOPS-663 — Jira](https://valispace.atlassian.net/browse/DEVOPS-663)_
