### PR TITLE
VALI-5456 :: Properly Document Existing Scripting Module Scripts

### DIFF
--- a/templates/simulations/electronicpressureregulator.m
+++ b/templates/simulations/electronicpressureregulator.m
@@ -1,0 +1,41 @@
+function [response] = main(data)
+    %% This is the first function to be called when executing the script
+    %  -----------------------------------------------------------------
+    %  Data: Scalar structure with data comming from Valispace.
+    %
+    %  Example of use:
+    %       mass = data.mass
+    %  ------------------------------------------------------------------
+    %  Response: Scalar structure with data to send to Valispace.
+    %
+    %  Example of use:
+    %       response = struct()
+    %       response.total_mass = data.mass * 10
+    %       response.double_mass = data.mass * 2
+    %  ------------------------------------------------------------------
+
+    % Get inputs from Valispace
+    P_in = data.P_in;
+    V_in = data.V_in;
+    
+    % Previous code from simulation
+    V_in = 1.2 ;  
+    F_1 = 25 ; 
+    PV_1 = P_in*V_in;
+    m_dot = 6; 
+    density = 5.761; 
+    A_inlet = m_dot / (density*V_in);
+    A_2 = A_inlet/2.5;
+    m_dot2 = 5;
+    V_2 = m_dot2/(density*A_2);
+    P_2 = PV_1/V_2; 
+    A_orifice = F_1/P_2; 
+    PV_2 = P_2*V_2; 
+    V_out = 70.58882;
+    Pout = PV_2/V_out;
+
+    % Send outputs back to Valispace
+    response = struct()
+    response.Pout = Pout;
+    
+end

--- a/templates/simulations/electronicpressureregulator.py
+++ b/templates/simulations/electronicpressureregulator.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from typing import Dict, Any
+import oct2py # pylint: disable=import-error
+
+
+def main(**kwargs) -> Dict[str, Any]:
+    """
+    This is the main function to execute your script and it must exists.
+    You shouldn't modify this function unless you are familiar with oct2py.
+
+    Other functions and files can be also created. You have at your disposal
+    to import Valispace API, oct2py, scipy, numpy and pint.
+
+    :param kwargs: Dictionary with data received from Valispace.
+    :type kwargs: Dict[str, Any]
+
+    :return: Dictionary with data to send back to Valispace.
+    :rtype: Dict[str, Any]
+    """
+    # Initialize octave and add all .m files to octave
+    octave = oct2py.Oct2Py()
+    octave.addpath(str(Path(__file__).resolve().parent))
+
+    # Run main function from main.m and send response back to Valispace
+    return octave.main(kwargs)

--- a/templates/simulations/idealforcecoefficient.m
+++ b/templates/simulations/idealforcecoefficient.m
@@ -1,0 +1,54 @@
+function [response] = main(data)
+    %% This is the first function to be called when executing the script
+    %  -----------------------------------------------------------------
+    %  Data: Scalar structure with data comming from Valispace.
+    %
+    %  Example of use:
+    %       mass = data.mass
+    %  ------------------------------------------------------------------
+    %  Response: Scalar structure with data to send to Valispace.
+    %
+    %  Example of use:
+    %       response = struct()
+    %       response.total_mass = data.mass * 10
+    %       response.double_mass = data.mass * 2
+    %  ------------------------------------------------------------------
+
+    % Get inputs from Valispace
+    g = data.g;
+    SIGMA = data.SIGMA;
+    
+    % Previous code from simulation
+    k = 1e-5; %initial guess
+    Gamma = sqrt(g)*(2/(g+1))^((g+1)/(2*g-2));
+    a = 2*g/(g-1);
+    b = 2/g;
+    c = (g+1)/g;
+    f = Gamma/sqrt(a*(k^b-k^c)) - SIGMA; %f(x)
+    df = a*(c*Gamma*k^c-b*Gamma*k^b)/(2*k*(a*(k^b-k^c))^(3/2)); %f&#x27;(x)
+    k_next = k-f/df; %Next guess
+    difference = abs(k_next-k)/k;
+    counter = 0;
+    
+    while difference &gt; k*1e-2
+    
+        k = k_next;
+        f = Gamma/sqrt(a*(k^b-k^c)) - SIGMA; %f(x)
+    
+        df = a*(c*Gamma*k^c-b*Gamma*k^b)/(2*k*(a*(k^b-k^c))^(3/2)); %f&#x27;(x)
+        k_next = k-f/df;%Next guess
+        difference = abs(k_next-k);
+        counter = counter + 1;
+    
+    endwhile
+    
+    C_F = Gamma*sqrt(a*(1-k^((g-1)/g)))+SIGMA*(k);
+    k = k_next;
+
+    % Send outputs back to Valispace
+    response = struct()
+    response.C_F = C_F;
+    response.k = k;
+    
+end
+    

--- a/templates/simulations/idealforcecoefficient.py
+++ b/templates/simulations/idealforcecoefficient.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from typing import Dict, Any
+import oct2py # pylint: disable=import-error
+
+
+def main(**kwargs) -> Dict[str, Any]:
+    """
+    This is the main function to execute your script and it must exists.
+    You shouldn't modify this function unless you are familiar with oct2py.
+
+    Other functions and files can be also created. You have at your disposal
+    to import Valispace API, oct2py, scipy, numpy and pint.
+
+    :param kwargs: Dictionary with data received from Valispace.
+    :type kwargs: Dict[str, Any]
+
+    :return: Dictionary with data to send back to Valispace.
+    :rtype: Dict[str, Any]
+    """
+    # Initialize octave and add all .m files to octave
+    octave = oct2py.Oct2Py()
+    octave.addpath(str(Path(__file__).resolve().parent))
+
+    # Run main function from main.m and send response back to Valispace
+    return octave.main(kwargs)


### PR DESCRIPTION
Scripting examples from [demonstration](https://demonstration.valispace.com/)/[models](https://models.valispace.com/) deployment added to source control.

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-octave/pull/31/commits/70d78fc1860c691490d2bdd1b9d49605c7810af2"><code>70d78fc</code></a> Add to source control current scripting examples
</li>
</ul>
</details>

<hr>

_More details about this issue at [VALI-5456 — Jira](https://valispace.atlassian.net/browse/VALI-5456)_
