### PR TITLE
VALI-5012 :: Use the same 'pint' dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-# Valispace packages
-valispace==0.1.16   # Valispace API
+# Valispace packages (mandatory)
+valispace==0.1.16 # Valispace Python API
 
-# Basic scientifical packages
-oct2py==5.3.0       # Python interface to Octave
-pint==0.18          # Python library used for scientific
-scipy==1.7.3        # Python library to define, operate and manipulate physical quantities
+# Basic scientifical packages (mandatory)
+oct2py==5.3.0 # Python to GNU Octave bridge
+git+https://git@github.com/valispace/pint.git@0.21.dev0+valispace#egg=pint # Physical quantities module (Valispace version)
+scipy==1.9.3 # Fundamental algorithms for scientific computing in Python
+
+# Add your packages here (optional)


### PR DESCRIPTION
Project requirements changed to reference [Valispace Pint implementation](https://github.com/valispace/pint).

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-octave/pull/32/commits/e6f7aeadc5ce941ac69e20fe099e5b498774561b"><code>e6f7aea</code></a> Use the same 'pint' dependency across the valispace
</li>
</ul>
</details>

<hr>

_More details about this issue at [VALI-5012 — Jira](https://valispace.atlassian.net/browse/VALI-5012)_
