### PR TITLE
DEVOPS-686 :: Standardize valifn-octave Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,167 +1,236 @@
 # -----------------------------------------------------------------------------
-# BACKEND - DJANGO / PYTHON
+# SYSTEM
 # -----------------------------------------------------------------------------
 
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-.pytest_cache
+**/.bash_history
+**/.DS_Store
+**/Thumbs.db
 
-# C extensions
-*.so
+# -----------------------------------------------------------------------------
+# KEYS & TEMPORARY FILES
+# -----------------------------------------------------------------------------
 
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
+**/configs/aws/*/aws-credentials.json
+**/configs/aws/*/compose.temp.yml
+**/configs/aws/*/db.creds.json
+**/configs/aws/*/db.sql
+**/configs/aws/*/dns-add-record.json
+**/configs/aws/*/dns-delete-record.json
+**/configs/vault/
+**/*.pem
+**/*.pub
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
+# -----------------------------------------------------------------------------
+# IDEs and EDITORS
+# -----------------------------------------------------------------------------
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
+**/.c9/
+**/.history
+**/.idea/
+**/.settings/
+**/.classpath
+**/.project
+**/.mr.developer.cfg
+**/.pydevproject
+**/*.chproj
+**/*.launch
+**/*.sublime-*
+**/*.sublime-workspace
+**/.vscode/
 
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
+# -----------------------------------------------------------------------------
+# ENVIRONMENTS
+# -----------------------------------------------------------------------------
 
-# Translations
-*.mo
-*.pot
+**/ENV/
+**/env/
+**/env.bak/
+**/env_*/
+**/env3/
+**/venv/
+**/venv.bak/
+**/.env/
+**/.venv/
 
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-media/
+# -----------------------------------------------------------------------------
+# GIT
+# -----------------------------------------------------------------------------
 
-# Flask stuff:
-instance/
-.webassets-cache
+**/.git/
+**/.gitignore
 
-# Scrapy stuff:
-.scrapy
+# -----------------------------------------------------------------------------
+# GITHUB
+# -----------------------------------------------------------------------------
 
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
+**/.github/
 
 # -----------------------------------------------------------------------------
 # LOCAL CONFIGURATIONS & SETTINGS
 # -----------------------------------------------------------------------------
 
-local.py
-result.json
-
+**/settings/local.py
+**/README.md
+**/LICENSE
+**/.exclude
 
 # -----------------------------------------------------------------------------
-# SYSTEM
+# DOCKER
 # -----------------------------------------------------------------------------
 
-# IDEs and editors
-.idea/
-.vscode/
-.project
-.pydevproject
-.mr.developer.cfg
-.classpath
-.c9/
-*.launch
-.settings/
-*.chproj
-*.sublime-*
-*.sublime-workspace
-.DS_Store
-.vscode/
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-.history
+**/docker-compose.override.yml
+**/docker-compose.local.yml
+**/local.yml
 
-# System Files
-.DS_Store
-Thumbs.db
-*.icloud
-thumbnail_kvstore*
-octave-workspace
-.bash_history
-nginx_signing*
-*.sock
-*.sock.lock
-*.bk
+# -----------------------------------------------------------------------------
+# BACKEND - DJANGO / PYTHON
+# -----------------------------------------------------------------------------
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/.pytest_cache
+
+# C extensions
+**/*.so
+
+# Distribution / packaging
+**/.Python
+**/build/
+**/develop-eggs/
+**/dist/
+**/downloads/
+**/eggs/
+**/.eggs/
+**/lib/
+**/lib64/
+**/parts/
+**/sdist/
+**/var/
+**/wheels/
+**/share/python-wheels/
+**/*.egg-info/
+**/.installed.cfg
+**/*.egg
+**/MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+
+**/*.manifest
+**/*.spec
+
+# Installer logs
+**/pip-log.txt
+**/pip-delete-this-directory.txt
+
+# Lint
+**/.pylintrc
+
+# Unit test / coverage reports
+**/htmlcov/
+**/locust/
+**/.tox/
+**/.nox/
+**/coverage/
+**/.coveragerc
+**/.coverage
+**/.coverage.*
+**/coverage.xml
+**/*.cover
+**/.cache/
+**/nosetests.xml
+**/.hypothesis/
+**/.pytest_cache/
+**/.pytest-queries
+**/pyproject.toml
+**/pytest.ini
+**/sonar-project.properties
+**/.scannerwork/
+
+# Translations
+**/*.mo
+**/*.pot
+
+# Django stuff:
+**/*.log
+**/local_settings.py
+**/db.sqlite3
+**/media/
+**/*.box
+**/*.pyc
+**/*.pyo
+**/bower_components/
+**/configs/vault/
+**/deployment_*.py
+**/dump.rdb
+**/nohup.out
+**/octave-core
+**/parser.out
+**/parsetab.py
+**/personal_data/
+**/backups
+**/mod_wsgi-4.4.21/*
+**/postgres-data
+**/redis-stable
+**/static/
+**/staticfiles/
+
+# Flask stuff:
+**/instance/
+**/.webassets-cache/
+
+# Scrapy stuff:
+**/.scrapy
+
+# Sphinx documentation
+**/docs/
+**/_build
+**/_autosummary
+
+# PyBuilder
+**/target/
+
+# Jupyter Notebook
+**/.ipynb_checkpoints
+**/*.ipynb
+
+# IPython
+**/profile_default/
+**/ipython_config.py
+
+# pyenv
+**/.python-version
+
+# celery beat schedule file
+**/celerybeat-schedule
+
+# SageMath parsed files
+**/*.sage.py
+
+# Spyder project settings
+**/.spyderproject
+**/.spyproject
+
+# Rope project settings
+**/.ropeproject
+
+# mkdocs documentation
+**/site
+
+# mypy
+**/mypyls/
+**/.mypy_cache/
+**/.dmypy.json
+**/dmypy.json
+
+# Pyre type checker
+**/.pyre
+
+# pyenv
+**/.python-version
+
+# Requirements
+**/requirements-*.txt

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,32 +1,47 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-buster
 
+LABEL org.opencontainers.image.description "Octave docker image to be used by the Valispace Scripting Module"
 LABEL maintainer="Valispace DevOps <devops@valispace.com>"
 
-# Set environment variables
-ENV PYTHONUNBUFFERED=1 \
-    DJANGO_SETTINGS_MODULE="settings.docker"
+# Activate unattended package installation with default answers for all questions
+ENV DEBIAN_FRONTEND="noninteractive"
+# Suppress apt-key warning about standard out not being a terminal (use in this script is safe)
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE="DontWarn"
+# Suppress pip warning about running as root user (use in this script is safe)
+ENV PIP_ROOT_USER_ACTION="ignore"
+# Make sure all python messages always reach the console
+ENV PYTHONUNBUFFERED=1
 
-ARG DEBIAN_FRONTEND=noninteractive \
-    APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
+# Copy application source code to docker image
+COPY ./backend /opt/valispace/scripting/
 
-# Copy the application source code to docker image and install dependencies
-COPY ./ /valifn
-WORKDIR /valifn/backend
+# Use bash as shell
+SHELL [ "/bin/bash", "-c" ]
 
-RUN set -e && \
-    # Install apt-utils
-    apt-get --quiet update && \
-    apt-get --quiet --no-install-recommends --assume-yes install apt-utils 2>&1 | grep -v "debconf: delaying package configuration, since apt-utils is not installed" && \
-    # Install octave
-    apt-get --quiet update && \
-    apt-get --quiet --no-install-recommends --assume-yes install octave && \
-    # Install git
-    apt-get --quiet update && \
-    apt-get --quiet --no-install-recommends --assume-yes install git && \
-    # Install python dependencies for the application
-    pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir --requirement requirements.txt
+# Stop execution immediately when a command fails
+RUN set -e
+
+# Install application dependencies (apt-get)
+RUN apt-get --quiet update && apt-get --quiet --no-install-recommends --fix-broken --assume-yes install apt-utils 2>&1 | grep -v "debconf: delaying package configuration, since apt-utils is not installed"
+RUN apt-get --quiet update && apt-get --quiet --no-install-recommends --fix-broken --assume-yes install git
+RUN apt-get --quiet update && apt-get --quiet --no-install-recommends --fix-broken --assume-yes install octave
+# Install application dependencies (pip)
+RUN pip --no-input --exists-action w install --upgrade pip wheel setuptools
+RUN pip --no-input --exists-action w install --requirement /opt/valispace/scripting/requirements.txt
+
+# Configure logs
+RUN mkdir --parents /var/log/valispace/scripting
+# Cleanup caches (apt-get)
+RUN apt-get --quiet --assume-yes autoremove && apt-get --quiet autoclean && rm --force --recursive /var/lib/apt/lists/* && rm --force --recursive /var/cache/apt/*
+# Cleanup caches (pip)
+RUN pip cache purge
+
+# Set working dir (necessary for relative paths)
+WORKDIR /opt/valispace/scripting
+
+# Compatibility with previous versions
+RUN ln --symbolic /opt/valispace/scripting /valifn
 
 # No need to track logs because container is constantly
 # destroyed after each execution or failure
-CMD ["tail", "-f", "/dev/null"]
+CMD ["tail", "--follow", "/dev/null"]


### PR DESCRIPTION
* `Dockerfile` modified to follow a common pattern between repositories
* Valispace application inside docker defined to `/opt/valispace/scripting`
* Valispace application logs inside docker defined to `/var/log/valispace/scripting`
* `.dockerignore` updated to exclude all unnecessary files from the docker

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-octave/pull/42/commits/a79dcdbeb86ec3f91c1df0dded0adb2c108aac56"><code>a79dcdb</code></a> Dockerfile modified to follow a common pattern between repositories
</li>
</ul>
</details>

<hr>

_More details about this issue at [DEVOPS-686 — Jira](https://valispace.atlassian.net/browse/DEVOPS-686)_
