### PR TITLE
DEVOPS-704 :: Add label 'version' to valifn-octave Dockerfile

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.10-slim-buster
 
 LABEL org.opencontainers.image.description "Octave docker image to be used by the Valispace Scripting Module"
 LABEL maintainer="Valispace DevOps <devops@valispace.com>"
+LABEL version="0.0.0"
 
 # Activate unattended package installation with default answers for all questions
 ENV DEBIAN_FRONTEND="noninteractive"


### PR DESCRIPTION
Docker label `version` added to dockerfile and docker build command, thus allowing to quickly identify the `valifn-octave` version running on the docker.

```bash
docker inspect IMAGE | jq '.[0].Config.Labels'
```

<details>
<summary>Commits</summary>
<ul>
<li>
<a href="https://github.com/valispace/valifn-octave/pull/43/commits/4d8d992fe8bd4e201781bf3ba5d8f01eb544d559"><code>4d8d992</code></a> Docker label 'version' added to docker build command
</li>
</ul>
</details>

<hr>

_More details about this issue at [DEVOPS-704 — Jira](https://valispace.atlassian.net/browse/DEVOPS-704)_
